### PR TITLE
fix(macos-glsl-shader-compat): Changed MacOS device rendering setting

### DIFF
--- a/demo/project.godot
+++ b/demo/project.godot
@@ -50,4 +50,5 @@ select={
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0
+rendering_device/driver.macos="vulkan"
 viewport/hdr_2d=true


### PR DESCRIPTION
> Changed MacOS device rendering setting to "Vulkan" for GLSL shaders to work. Only tested on Mac Apple Silicon M1. This does not affect Windows.